### PR TITLE
Hyprland Window Moving

### DIFF
--- a/home/hyprland/default.nix
+++ b/home/hyprland/default.nix
@@ -223,8 +223,8 @@ in {
           "$mainMod, k, movefocus, u"
           "$mainMod, j, movefocus, d"
 
-          "$mainMod SHIFT, j, split-changemonitorsilent, next"
-          "$mainMod SHIFT, k, split-changemonitorsilent, prev"
+          "$mainMod SHIFT, j, split-changemonitor, next"
+          "$mainMod SHIFT, k, split-changemonitor, prev"
 
           "$mainMod, mouse_down, workspace, e+1"
           "$mainMod, mouse_up, workspace, e-1"

--- a/home/hyprland/default.nix
+++ b/home/hyprland/default.nix
@@ -229,7 +229,7 @@ in {
           "$mainMod, mouse_down, workspace, e+1"
           "$mainMod, mouse_up, workspace, e-1"
         ]
-        ++ map (n: "$mainMod SHIFT, ${toString n}, split-movetoworkspacesilent, ${toString (
+        ++ map (n: "$mainMod SHIFT, ${toString n}, split-movetoworkspace, ${toString (
           if n == 0
           then 10
           else n


### PR DESCRIPTION
Windows moving shouldnt be silent by default. Would be good to have this as an option for which is default. I far more commonly move a window from a crowded workspace to an empty one where i want to use the window I moved instead of trying to rid of a window/